### PR TITLE
Fix acceptance tests for powerdns 4.1.

### DIFF
--- a/powerdns/resource_powerdns_record_test.go
+++ b/powerdns/resource_powerdns_record_test.go
@@ -272,8 +272,8 @@ func testAccCheckPDNSRecordExists(n string) resource.TestCheckFunc {
 
 const testPDNSRecordConfigA = `
 resource "powerdns_record" "test-a" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "A"
 	ttl = 60
 	records = [ "1.1.1.1", "2.2.2.2" ]
@@ -282,8 +282,8 @@ resource "powerdns_record" "test-a" {
 const testPDNSRecordConfigHyphenedWithCount = `
 resource "powerdns_record" "test-counted" {
 	count = "2"
-	zone = "sysa.xyz"
-	name = "redis-${count.index}.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis-${count.index}.sysa.xyz."
 	type = "A"
 	ttl = 60
 	records = [ "1.1.1.${count.index}" ]
@@ -291,26 +291,26 @@ resource "powerdns_record" "test-counted" {
 
 const testPDNSRecordConfigAAAA = `
 resource "powerdns_record" "test-aaaa" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "AAAA"
 	ttl = 60
-	records = [ "2001:DB8:2000:bf0::1", "2001:DB8:2000:bf1::1" ]
+	records = [ "2001:db8:2000:bf0::1", "2001:db8:2000:bf1::1" ]
 }`
 
 const testPDNSRecordConfigCNAME = `
 resource "powerdns_record" "test-cname" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "CNAME"
 	ttl = 60
-	records = [ "redis.example.com" ]
+	records = [ "redis.example.com." ]
 }`
 
 const testPDNSRecordConfigHINFO = `
 resource "powerdns_record" "test-hinfo" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "HINFO"
 	ttl = 60
 	records = [ "\"PC-Intel-2.4ghz\" \"Linux\"" ]
@@ -318,8 +318,8 @@ resource "powerdns_record" "test-hinfo" {
 
 const testPDNSRecordConfigLOC = `
 resource "powerdns_record" "test-loc" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "LOC"
 	ttl = 60
 	records = [ "51 56 0.123 N 5 54 0.000 E 4.00m 1.00m 10000.00m 10.00m" ]
@@ -327,26 +327,26 @@ resource "powerdns_record" "test-loc" {
 
 const testPDNSRecordConfigMX = `
 resource "powerdns_record" "test-mx" {
-  zone = "sysa.xyz"
-	name = "sysa.xyz"
+	zone = "sysa.xyz."
+	name = "sysa.xyz."
 	type = "MX"
 	ttl = 60
-	records = [ "10 mail.example.com" ]
+	records = [ "10 mail.example.com." ]
 }`
 
 const testPDNSRecordConfigMXMulti = `
 resource "powerdns_record" "test-mx-multi" {
-  zone = "sysa.xyz"
-	name = "sysa.xyz"
+	zone = "sysa.xyz."
+	name = "sysa.xyz."
 	type = "MX"
 	ttl = 60
-	records = [ "10 mail1.example.com", "20 mail2.example.com" ]
+	records = [ "10 mail1.example.com.", "20 mail2.example.com." ]
 }`
 
 const testPDNSRecordConfigNAPTR = `
 resource "powerdns_record" "test-naptr" {
-  zone = "sysa.xyz"
-	name = "sysa.xyz"
+	zone = "sysa.xyz"
+	name = "sysa.xyz."
 	type = "NAPTR"
 	ttl = 60
 	records = [ "100 50 \"s\" \"z3950+I2L+I2C\" \"\" _z3950._tcp.gatech.edu'." ]
@@ -354,17 +354,17 @@ resource "powerdns_record" "test-naptr" {
 
 const testPDNSRecordConfigNS = `
 resource "powerdns_record" "test-ns" {
-  zone = "sysa.xyz"
-	name = "lab.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "lab.sysa.xyz."
 	type = "NS"
 	ttl = 60
-	records = [ "ns1.sysa.xyz", "ns2.sysa.xyz" ]
+	records = [ "ns1.sysa.xyz.", "ns2.sysa.xyz." ]
 }`
 
 const testPDNSRecordConfigSPF = `
 resource "powerdns_record" "test-spf" {
-  zone = "sysa.xyz"
-	name = "sysa.xyz"
+	zone = "sysa.xyz."
+	name = "sysa.xyz."
 	type = "SPF"
 	ttl = 60
 	records = [ "\"v=spf1 +all\"" ]
@@ -372,8 +372,8 @@ resource "powerdns_record" "test-spf" {
 
 const testPDNSRecordConfigSSHFP = `
 resource "powerdns_record" "test-sshfp" {
-  zone = "sysa.xyz"
-	name = "ssh.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "ssh.sysa.xyz."
 	type = "SSHFP"
 	ttl = 60
 	records = [ "1 1 123456789abcdef67890123456789abcdef67890" ]
@@ -381,17 +381,17 @@ resource "powerdns_record" "test-sshfp" {
 
 const testPDNSRecordConfigSRV = `
 resource "powerdns_record" "test-srv" {
-  zone = "sysa.xyz"
-	name = "_redis._tcp.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "_redis._tcp.sysa.xyz."
 	type = "SRV"
 	ttl = 60
-	records = [ "0 10 6379 redis1.sysa.xyz", "0 10 6379 redis2.sysa.xyz", "10 10 6379 redis-replica.sysa.xyz" ]
+	records = [ "0 10 6379 redis1.sysa.xyz.", "0 10 6379 redis2.sysa.xyz.", "10 10 6379 redis-replica.sysa.xyz." ]
 }`
 
 const testPDNSRecordConfigTXT = `
 resource "powerdns_record" "test-txt" {
-  zone = "sysa.xyz"
-	name = "text.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "text.sysa.xyz."
 	type = "TXT"
 	ttl = 60
 	records = [ "\"text record payload\"" ]

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -20,7 +20,7 @@ For the v1 API (PowerDNS version 4):
 # Add a record to the zone
 resource "powerdns_record" "foobar" {
   zone    = "example.com."
-  name    = "www.example.com"
+  name    = "www.example.com."
   type    = "A"
   ttl     = 300
   records = ["192.168.0.11"]
@@ -44,8 +44,8 @@ For the legacy API (PowerDNS version 3.4):
 ```hcl
 # Add a record to the zone
 resource "powerdns_record" "foobar" {
-  zone    = "example.com"
-  name    = "www.example.com"
+  zone    = "example.com."
+  name    = "www.example.com."
   type    = "A"
   ttl     = 300
   records = ["192.168.0.11"]
@@ -61,4 +61,3 @@ The following arguments are supported:
 * `type` - (Required) The record type.
 * `ttl` - (Required) The TTL of the record.
 * `records` - (Required) A string list of records.
-


### PR DESCRIPTION
* Add trailing dots to record names to fix non-canonical warnings
* Lowercase record names to fix spurious recreates

We could also change the code to automatically add trailing dots, lowercase records, and suppress diffs, but IMO it's better to pass values to powerdns with minimal modification--users should understand how powerdns works without having to learn a slightly different interface exposed by the provider.

Output of acceptance tests running against 4.1 using postgres backend:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?   	github.com/terraform-providers/terraform-provider-powerdns	[no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProviderImpl
--- PASS: TestProviderImpl (0.00s)
=== RUN   TestAccPDNSRecord_A
--- PASS: TestAccPDNSRecord_A (0.24s)
=== RUN   TestAccPDNSRecord_WithCount
--- PASS: TestAccPDNSRecord_WithCount (0.31s)
=== RUN   TestAccPDNSRecord_AAAA
--- PASS: TestAccPDNSRecord_AAAA (0.28s)
=== RUN   TestAccPDNSRecord_CNAME
--- PASS: TestAccPDNSRecord_CNAME (0.22s)
=== RUN   TestAccPDNSRecord_HINFO
--- PASS: TestAccPDNSRecord_HINFO (0.22s)
=== RUN   TestAccPDNSRecord_LOC
--- PASS: TestAccPDNSRecord_LOC (0.22s)
=== RUN   TestAccPDNSRecord_MX
--- PASS: TestAccPDNSRecord_MX (0.42s)
=== RUN   TestAccPDNSRecord_NAPTR
--- PASS: TestAccPDNSRecord_NAPTR (0.21s)
=== RUN   TestAccPDNSRecord_NS
--- PASS: TestAccPDNSRecord_NS (0.22s)
=== RUN   TestAccPDNSRecord_SPF
--- PASS: TestAccPDNSRecord_SPF (0.27s)
=== RUN   TestAccPDNSRecord_SSHFP
--- PASS: TestAccPDNSRecord_SSHFP (0.29s)
=== RUN   TestAccPDNSRecord_SRV
--- PASS: TestAccPDNSRecord_SRV (0.24s)
=== RUN   TestAccPDNSRecord_TXT
--- PASS: TestAccPDNSRecord_TXT (0.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-powerdns/powerdns	3.374s
```

Resolves #6, cc @anuriq @grubernaut 