### PR TITLE
Manage zones

### DIFF
--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -78,6 +78,7 @@ type ZoneInfo struct {
 	Serial             int64               `json:"serial"`
 	Records            []Record            `json:"records,omitempty"`
 	ResourceRecordSets []ResourceRecordSet `json:"rrsets,omitempty"`
+	Nameservers        []string            `json:"nameservers,omitempty"`
 }
 
 type Record struct {
@@ -114,14 +115,13 @@ func (rrSet *ResourceRecordSet) Id() string {
 	return rrSet.Name + idSeparator + rrSet.Type
 }
 
-// Returns name and type of record or record set based on it's ID
+// Returns name and type of record or record set based on its ID
 func parseId(recId string) (string, string, error) {
 	s := strings.Split(recId, idSeparator)
 	if len(s) == 2 {
 		return s[0], s[1], nil
-	} else {
-		return "", "", fmt.Errorf("Unknown record ID format")
 	}
+	return "", "", fmt.Errorf("Unknown record ID format")
 }
 
 // Detects the API version in use on the server
@@ -139,14 +139,12 @@ func (client *Client) detectApiVersion() (int, error) {
 	defer resp.Body.Close()
 	if resp.StatusCode == 200 {
 		return 1, nil
-	} else {
-		return 0, nil
 	}
+	return 0, nil
 }
 
 // Returns all Zones of server, without records
 func (client *Client) ListZones() ([]ZoneInfo, error) {
-
 	req, err := client.newRequest("GET", "/servers/localhost/zones", nil)
 	if err != nil {
 		return nil, err
@@ -166,6 +164,111 @@ func (client *Client) ListZones() ([]ZoneInfo, error) {
 	}
 
 	return zoneInfos, nil
+}
+
+// GetZone gets a zone
+func (c *Client) GetZone(name string) (ZoneInfo, error) {
+	req, err := c.newRequest("GET", fmt.Sprintf("/servers/localhost/zones/%s", name), nil)
+	if err != nil {
+		return ZoneInfo{}, err
+	}
+
+	resp, err := c.Http.Do(req)
+	if err != nil {
+		return ZoneInfo{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errorResp := new(errorResponse)
+		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
+			return ZoneInfo{}, fmt.Errorf("Error getting zone: %s", name)
+		}
+		return ZoneInfo{}, fmt.Errorf("Error getting zone: %s, reason: %q", name, errorResp.ErrorMsg)
+	}
+
+	var zoneInfo ZoneInfo
+	err = json.NewDecoder(resp.Body).Decode(&zoneInfo)
+	if err != nil {
+		return ZoneInfo{}, err
+	}
+
+	return zoneInfo, nil
+}
+
+// ZoneExists checks if requested zone exists
+func (c *Client) ZoneExists(name string) (bool, error) {
+	req, err := c.newRequest("GET", fmt.Sprintf("/servers/localhost/zones/%s", name), nil)
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := c.Http.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
+		errorResp := new(errorResponse)
+		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
+			return false, fmt.Errorf("Error getting zone: %s", name)
+		}
+		return false, fmt.Errorf("Error getting zone: %s, reason: %q", name, errorResp.ErrorMsg)
+	}
+
+	return resp.StatusCode == http.StatusOK, nil
+}
+
+func (c *Client) CreateZone(zoneInfo ZoneInfo) error {
+	body, err := json.Marshal(zoneInfo)
+	if err != nil {
+		return err
+	}
+
+	req, err := c.newRequest("POST", "/servers/localhost/zones", body)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.Http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		errorResp := new(errorResponse)
+		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
+			return fmt.Errorf("Error creating zone: %s", zoneInfo.Name)
+		}
+		return fmt.Errorf("Error creating zone: %s, reason: %q", zoneInfo.Name, errorResp.ErrorMsg)
+	}
+
+	return nil
+}
+
+// DeleteZone deletes a zone
+func (c *Client) DeleteZone(name string) error {
+	req, err := c.newRequest("DELETE", fmt.Sprintf("/servers/localhost/zones/%s", name), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.Http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 204 {
+		errorResp := new(errorResponse)
+		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
+			return fmt.Errorf("Error deleting zone: %s", name)
+		}
+		return fmt.Errorf("Error deleting zone: %s, reason: %q", name, errorResp.ErrorMsg)
+	}
+	return nil
 }
 
 // Returns all records in Zone
@@ -224,9 +327,8 @@ func (client *Client) ListRecordsByID(zone string, recId string) ([]Record, erro
 	name, tpe, err := parseId(recId)
 	if err != nil {
 		return nil, err
-	} else {
-		return client.ListRecordsInRRSet(zone, name, tpe)
 	}
+	return client.ListRecordsInRRSet(zone, name, tpe)
 }
 
 // Checks if requested record exists in Zone
@@ -249,45 +351,8 @@ func (client *Client) RecordExistsByID(zone string, recId string) (bool, error) 
 	name, tpe, err := parseId(recId)
 	if err != nil {
 		return false, err
-	} else {
-		return client.RecordExists(zone, name, tpe)
 	}
-}
-
-// Creates new record with single content entry
-func (client *Client) CreateRecord(zone string, record Record) (string, error) {
-	reqBody, _ := json.Marshal(zonePatchRequest{
-		RecordSets: []ResourceRecordSet{
-			{
-				Name:       record.Name,
-				Type:       record.Type,
-				ChangeType: "REPLACE",
-				Records:    []Record{record},
-			},
-		},
-	})
-
-	req, err := client.newRequest("PATCH", fmt.Sprintf("/servers/localhost/zones/%s", zone), reqBody)
-	if err != nil {
-		return "", err
-	}
-
-	resp, err := client.Http.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 && resp.StatusCode != 204 {
-		errorResp := new(errorResponse)
-		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-			return "", fmt.Errorf("Error creating record: %s", record.Id())
-		} else {
-			return "", fmt.Errorf("Error creating record: %s, reason: %q", record.Id(), errorResp.ErrorMsg)
-		}
-	} else {
-		return record.Id(), nil
-	}
+	return client.RecordExists(zone, name, tpe)
 }
 
 // Creates new record set in Zone
@@ -313,12 +378,10 @@ func (client *Client) ReplaceRecordSet(zone string, rrSet ResourceRecordSet) (st
 		errorResp := new(errorResponse)
 		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
 			return "", fmt.Errorf("Error creating record set: %s", rrSet.Id())
-		} else {
-			return "", fmt.Errorf("Error creating record set: %s, reason: %q", rrSet.Id(), errorResp.ErrorMsg)
 		}
-	} else {
-		return rrSet.Id(), nil
+		return "", fmt.Errorf("Error creating record set: %s, reason: %q", rrSet.Id(), errorResp.ErrorMsg)
 	}
+	return rrSet.Id(), nil
 }
 
 // Deletes record set from Zone
@@ -348,20 +411,17 @@ func (client *Client) DeleteRecordSet(zone string, name string, tpe string) erro
 		errorResp := new(errorResponse)
 		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
 			return fmt.Errorf("Error deleting record: %s %s", name, tpe)
-		} else {
-			return fmt.Errorf("Error deleting record: %s %s, reason: %q", name, tpe, errorResp.ErrorMsg)
 		}
-	} else {
-		return nil
+		return fmt.Errorf("Error deleting record: %s %s, reason: %q", name, tpe, errorResp.ErrorMsg)
 	}
+	return nil
 }
 
-// Deletes record from Zone by it's ID
+// Deletes record from Zone by its ID
 func (client *Client) DeleteRecordSetByID(zone string, recId string) error {
 	name, tpe, err := parseId(recId)
 	if err != nil {
 		return err
-	} else {
-		return client.DeleteRecordSet(zone, name, tpe)
 	}
+	return client.DeleteRecordSet(zone, name, tpe)
 }

--- a/powerdns/provider.go
+++ b/powerdns/provider.go
@@ -23,6 +23,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"powerdns_zone":   resourcePDNSZone(),
 			"powerdns_record": resourcePDNSRecord(),
 		},
 

--- a/powerdns/resource_powerdns_record.go
+++ b/powerdns/resource_powerdns_record.go
@@ -1,9 +1,8 @@
 package powerdns
 
 import (
-	"log"
-
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -141,7 +140,6 @@ func resourcePDNSRecordExists(d *schema.ResourceData, meta interface{}) (bool, e
 
 	if err != nil {
 		return false, fmt.Errorf("Error checking PowerDNS Record: %s", err)
-	} else {
-		return exists, nil
 	}
+	return exists, nil
 }

--- a/powerdns/resource_powerdns_record_test.go
+++ b/powerdns/resource_powerdns_record_test.go
@@ -272,8 +272,8 @@ func testAccCheckPDNSRecordExists(n string) resource.TestCheckFunc {
 
 const testPDNSRecordConfigA = `
 resource "powerdns_record" "test-a" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "A"
 	ttl = 60
 	records = [ "1.1.1.1", "2.2.2.2" ]
@@ -282,8 +282,8 @@ resource "powerdns_record" "test-a" {
 const testPDNSRecordConfigHyphenedWithCount = `
 resource "powerdns_record" "test-counted" {
 	count = "2"
-	zone = "sysa.xyz"
-	name = "redis-${count.index}.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis-${count.index}.sysa.xyz."
 	type = "A"
 	ttl = 60
 	records = [ "1.1.1.${count.index}" ]
@@ -291,26 +291,26 @@ resource "powerdns_record" "test-counted" {
 
 const testPDNSRecordConfigAAAA = `
 resource "powerdns_record" "test-aaaa" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "AAAA"
 	ttl = 60
-	records = [ "2001:DB8:2000:bf0::1", "2001:DB8:2000:bf1::1" ]
+	records = [ "2001:db8:2000:bf0::1", "2001:db8:2000:bf1::1" ]
 }`
 
 const testPDNSRecordConfigCNAME = `
 resource "powerdns_record" "test-cname" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "CNAME"
 	ttl = 60
-	records = [ "redis.example.com" ]
+	records = [ "redis.example.com." ]
 }`
 
 const testPDNSRecordConfigHINFO = `
 resource "powerdns_record" "test-hinfo" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "HINFO"
 	ttl = 60
 	records = [ "\"PC-Intel-2.4ghz\" \"Linux\"" ]
@@ -318,8 +318,8 @@ resource "powerdns_record" "test-hinfo" {
 
 const testPDNSRecordConfigLOC = `
 resource "powerdns_record" "test-loc" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "LOC"
 	ttl = 60
 	records = [ "51 56 0.123 N 5 54 0.000 E 4.00m 1.00m 10000.00m 10.00m" ]
@@ -327,26 +327,26 @@ resource "powerdns_record" "test-loc" {
 
 const testPDNSRecordConfigMX = `
 resource "powerdns_record" "test-mx" {
-  zone = "sysa.xyz"
-	name = "sysa.xyz"
+	zone = "sysa.xyz."
+	name = "sysa.xyz."
 	type = "MX"
 	ttl = 60
-	records = [ "10 mail.example.com" ]
+	records = [ "10 mail.example.com." ]
 }`
 
 const testPDNSRecordConfigMXMulti = `
 resource "powerdns_record" "test-mx-multi" {
-  zone = "sysa.xyz"
-	name = "sysa.xyz"
+	zone = "sysa.xyz."
+	name = "sysa.xyz."
 	type = "MX"
 	ttl = 60
-	records = [ "10 mail1.example.com", "20 mail2.example.com" ]
+	records = [ "10 mail1.example.com.", "20 mail2.example.com." ]
 }`
 
 const testPDNSRecordConfigNAPTR = `
 resource "powerdns_record" "test-naptr" {
-  zone = "sysa.xyz"
-	name = "sysa.xyz"
+	zone = "sysa.xyz"
+	name = "sysa.xyz."
 	type = "NAPTR"
 	ttl = 60
 	records = [ "100 50 \"s\" \"z3950+I2L+I2C\" \"\" _z3950._tcp.gatech.edu'." ]
@@ -354,17 +354,17 @@ resource "powerdns_record" "test-naptr" {
 
 const testPDNSRecordConfigNS = `
 resource "powerdns_record" "test-ns" {
-  zone = "sysa.xyz"
-	name = "lab.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "lab.sysa.xyz."
 	type = "NS"
 	ttl = 60
-	records = [ "ns1.sysa.xyz", "ns2.sysa.xyz" ]
+	records = [ "ns1.sysa.xyz.", "ns2.sysa.xyz." ]
 }`
 
 const testPDNSRecordConfigSPF = `
 resource "powerdns_record" "test-spf" {
-  zone = "sysa.xyz"
-	name = "sysa.xyz"
+	zone = "sysa.xyz."
+	name = "sysa.xyz."
 	type = "SPF"
 	ttl = 60
 	records = [ "\"v=spf1 +all\"" ]
@@ -372,8 +372,8 @@ resource "powerdns_record" "test-spf" {
 
 const testPDNSRecordConfigSSHFP = `
 resource "powerdns_record" "test-sshfp" {
-  zone = "sysa.xyz"
-	name = "ssh.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "ssh.sysa.xyz."
 	type = "SSHFP"
 	ttl = 60
 	records = [ "1 1 123456789abcdef67890123456789abcdef67890" ]
@@ -381,17 +381,17 @@ resource "powerdns_record" "test-sshfp" {
 
 const testPDNSRecordConfigSRV = `
 resource "powerdns_record" "test-srv" {
-  zone = "sysa.xyz"
-	name = "_redis._tcp.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "_redis._tcp.sysa.xyz."
 	type = "SRV"
 	ttl = 60
-	records = [ "0 10 6379 redis1.sysa.xyz", "0 10 6379 redis2.sysa.xyz", "10 10 6379 redis-replica.sysa.xyz" ]
+	records = [ "0 10 6379 redis1.sysa.xyz.", "0 10 6379 redis2.sysa.xyz.", "10 10 6379 redis-replica.sysa.xyz." ]
 }`
 
 const testPDNSRecordConfigTXT = `
 resource "powerdns_record" "test-txt" {
-  zone = "sysa.xyz"
-	name = "text.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "text.sysa.xyz."
 	type = "TXT"
 	ttl = 60
 	records = [ "\"text record payload\"" ]

--- a/powerdns/resource_powerdns_zone.go
+++ b/powerdns/resource_powerdns_zone.go
@@ -1,0 +1,104 @@
+package powerdns
+
+import (
+	"log"
+
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourcePDNSZone() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePDNSZoneCreate,
+		Read:   resourcePDNSZoneRead,
+		Delete: resourcePDNSZoneDelete,
+		Exists: resourcePDNSZoneExists,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"kind": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"nameservers": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourcePDNSZoneCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	var nameservers []string
+	for _, nameserver := range d.Get("nameservers").(*schema.Set).List() {
+		nameservers = append(nameservers, nameserver.(string))
+	}
+
+	zoneInfo := ZoneInfo{
+		Name:        d.Get("name").(string),
+		Kind:        d.Get("kind").(string),
+		Nameservers: nameservers,
+	}
+
+	if err := client.CreateZone(zoneInfo); err != nil {
+		return err
+	}
+
+	d.SetId(zoneInfo.Name)
+
+	return nil
+}
+
+func resourcePDNSZoneRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	log.Printf("[DEBUG] Reading PowerDNS Zone: %s", d.Id())
+	zoneInfo, err := client.GetZone(d.Get("name").(string))
+	if err != nil {
+		return fmt.Errorf("Couldn't fetch PowerDNS Zone: %s", err)
+	}
+
+	d.Set("name", zoneInfo.Name)
+	d.Set("kind", zoneInfo.Kind)
+
+	return nil
+}
+
+func resourcePDNSZoneDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	log.Printf("[INFO] Deleting PowerDNS Zone: %s", d.Id())
+	err := client.DeleteZone(d.Get("name").(string))
+
+	if err != nil {
+		return fmt.Errorf("Error deleting PowerDNS Zone: %s", err)
+	}
+
+	return nil
+}
+
+func resourcePDNSZoneExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	name := d.Get("name").(string)
+
+	log.Printf("[INFO] Checking existence of PowerDNS Zone: %s", name)
+
+	client := meta.(*Client)
+	exists, err := client.ZoneExists(name)
+
+	if err != nil {
+		return false, fmt.Errorf("Error checking PowerDNS Zone: %s", err)
+	}
+	return exists, nil
+}

--- a/powerdns/resource_powerdns_zone_test.go
+++ b/powerdns/resource_powerdns_zone_test.go
@@ -1,0 +1,72 @@
+package powerdns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccPDNSZone(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPDNSZoneConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPDNSZoneExists("powerdns_zone.test"),
+					resource.TestCheckResourceAttr("powerdns_zone.test", "name", "sysa.abc."),
+					resource.TestCheckResourceAttr("powerdns_zone.test", "kind", "Native"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPDNSZoneDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "powerdns_zone" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(*Client)
+		exists, err := client.ZoneExists(rs.Primary.Attributes["zone"])
+		if err != nil {
+			return fmt.Errorf("Error checking if zone still exists: %#v", rs.Primary.ID)
+		}
+		if exists {
+			return fmt.Errorf("Zone still exists: %#v", rs.Primary.ID)
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckPDNSZoneExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		client := testAccProvider.Meta().(*Client)
+		exists, err := client.ZoneExists(rs.Primary.Attributes["name"])
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("Zone does not exist: %#v", rs.Primary.ID)
+		}
+		return nil
+	}
+}
+
+const testPDNSZoneConfig = `
+resource "powerdns_zone" "test" {
+	name = "sysa.abc."
+	kind = "Native"
+	nameservers = [ "ns1.sysa.abc.", "ns2.sysa.abc." ]
+}`

--- a/powerdns/resource_powerdns_zone_test.go
+++ b/powerdns/resource_powerdns_zone_test.go
@@ -68,5 +68,5 @@ const testPDNSZoneConfig = `
 resource "powerdns_zone" "test" {
 	name = "sysa.abc."
 	kind = "Native"
-	nameservers = [ "ns1.sysa.abc.", "ns2.sysa.abc." ]
+	nameservers = ["ns1.sysa.abc.", "ns2.sysa.abc."]
 }`

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -20,7 +20,7 @@ For the v1 API (PowerDNS version 4):
 # Add a record to the zone
 resource "powerdns_record" "foobar" {
   zone    = "example.com."
-  name    = "www.example.com"
+  name    = "www.example.com."
   type    = "A"
   ttl     = 300
   records = ["192.168.0.11"]
@@ -44,8 +44,8 @@ For the legacy API (PowerDNS version 3.4):
 ```hcl
 # Add a record to the zone
 resource "powerdns_record" "foobar" {
-  zone    = "example.com"
-  name    = "www.example.com"
+  zone    = "example.com."
+  name    = "www.example.com."
   type    = "A"
   ttl     = 300
   records = ["192.168.0.11"]
@@ -61,4 +61,3 @@ The following arguments are supported:
 * `type` - (Required) The record type.
 * `ttl` - (Required) The TTL of the record.
 * `records` - (Required) A string list of records.
-

--- a/website/docs/r/zone.html.markdown
+++ b/website/docs/r/zone.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "powerdns"
+page_title: "PowerDNS: powerdns_zone"
+sidebar_current: "docs-powerdns-zone"
+description: |-
+  Provides a PowerDNS zone.
+---
+
+# powerdns\_zone
+
+Provides a PowerDNS zone.
+
+## Example Usage
+
+For the v1 API (PowerDNS version 4):
+
+```hcl
+# Add a zone
+resource "powerdns_zone" "foobar" {
+  name    = "example.com."
+  kind    = "Native"
+  nameservers = ["ns1.example.com.", "ns2.example.com."]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of zone.
+* `kind` - (Required) The kind of the zone.
+* `nameservers` - (Required) The zone nameservers.


### PR DESCRIPTION
Based on #7.

[Resolves #2]

Test output:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?   	github.com/terraform-providers/terraform-provider-powerdns	[no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProviderImpl
--- PASS: TestProviderImpl (0.00s)
=== RUN   TestAccPDNSRecord_A
--- PASS: TestAccPDNSRecord_A (0.38s)
=== RUN   TestAccPDNSRecord_WithCount
--- PASS: TestAccPDNSRecord_WithCount (0.45s)
=== RUN   TestAccPDNSRecord_AAAA
--- PASS: TestAccPDNSRecord_AAAA (0.33s)
=== RUN   TestAccPDNSRecord_CNAME
--- PASS: TestAccPDNSRecord_CNAME (0.35s)
=== RUN   TestAccPDNSRecord_HINFO
--- PASS: TestAccPDNSRecord_HINFO (0.38s)
=== RUN   TestAccPDNSRecord_LOC
--- PASS: TestAccPDNSRecord_LOC (0.33s)
=== RUN   TestAccPDNSRecord_MX
--- PASS: TestAccPDNSRecord_MX (0.60s)
=== RUN   TestAccPDNSRecord_NAPTR
--- PASS: TestAccPDNSRecord_NAPTR (0.31s)
=== RUN   TestAccPDNSRecord_NS
--- PASS: TestAccPDNSRecord_NS (0.34s)
=== RUN   TestAccPDNSRecord_SPF
--- PASS: TestAccPDNSRecord_SPF (0.35s)
=== RUN   TestAccPDNSRecord_SSHFP
--- PASS: TestAccPDNSRecord_SSHFP (0.37s)
=== RUN   TestAccPDNSRecord_SRV
--- PASS: TestAccPDNSRecord_SRV (0.33s)
=== RUN   TestAccPDNSRecord_TXT
--- PASS: TestAccPDNSRecord_TXT (0.34s)
=== RUN   TestAccPDNSZone
--- PASS: TestAccPDNSZone (0.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-powerdns/powerdns	5.211s
```