### PR TITLE
Compose tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,14 @@ In order to test the provider, you can simply run `make test`.
 $ make test
 ```
 
-In order to run the full suite of Acceptance tests, run `make testacc`.
-
-*Note:* Acceptance tests create real resources, and often cost money to run.
+In order to run the full suite of acceptance tests, run `make testacc`.
 
 ```sh
 $ make testacc
+```
+
+You can also run acceptance tests using `docker-compose`:
+
+```sh
+docker-compose run --rm testacc
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3"
+services:
+  mysql:
+    image: mariadb
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+  pdns:
+    image: psitrax/powerdns
+    command:
+    - "--api"
+    - "--api-key=secret"
+    - "--webserver"
+    - "--webserver-address=0.0.0.0"
+    - "--webserver-allow-from=0.0.0.0/0"
+    environment:
+      MYSQL_USER: root
+      MYSQL_PASS: secret
+    depends_on:
+    - mysql
+  testacc:
+    image: golang
+    command:
+    - sh
+    - -c
+    - |
+      while true; do
+        if curl -f http://pdns:8081/api -H "X-API-Key: secret"; then
+          break
+        fi
+        sleep 1
+      done
+      curl -X POST http://pdns:8081/api/v1/servers/localhost/zones \
+        -d '{"name": "sysa.xyz.", "kind": "Native", "nameservers": ["ns1.sysa.xyz."]}' \
+        -H "X-API-Key: secret"
+      make testacc
+    environment:
+      PDNS_SERVER_URL: http://pdns:8081
+      PDNS_API_KEY: secret
+    volumes:
+    - .:/go/src/github.com/terraform-providers/terraform-provider-powerdns
+    working_dir: /go/src/github.com/terraform-providers/terraform-provider-powerdns
+    depends_on:
+    - pdns

--- a/powerdns/resource_powerdns_record_test.go
+++ b/powerdns/resource_powerdns_record_test.go
@@ -272,8 +272,8 @@ func testAccCheckPDNSRecordExists(n string) resource.TestCheckFunc {
 
 const testPDNSRecordConfigA = `
 resource "powerdns_record" "test-a" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "A"
 	ttl = 60
 	records = [ "1.1.1.1", "2.2.2.2" ]
@@ -282,8 +282,8 @@ resource "powerdns_record" "test-a" {
 const testPDNSRecordConfigHyphenedWithCount = `
 resource "powerdns_record" "test-counted" {
 	count = "2"
-	zone = "sysa.xyz"
-	name = "redis-${count.index}.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis-${count.index}.sysa.xyz."
 	type = "A"
 	ttl = 60
 	records = [ "1.1.1.${count.index}" ]
@@ -291,26 +291,26 @@ resource "powerdns_record" "test-counted" {
 
 const testPDNSRecordConfigAAAA = `
 resource "powerdns_record" "test-aaaa" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "AAAA"
 	ttl = 60
-	records = [ "2001:DB8:2000:bf0::1", "2001:DB8:2000:bf1::1" ]
+	records = [ "2001:db8:2000:bf0::1", "2001:db8:2000:bf1::1" ]
 }`
 
 const testPDNSRecordConfigCNAME = `
 resource "powerdns_record" "test-cname" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "CNAME"
 	ttl = 60
-	records = [ "redis.example.com" ]
+	records = [ "redis.example.com." ]
 }`
 
 const testPDNSRecordConfigHINFO = `
 resource "powerdns_record" "test-hinfo" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "HINFO"
 	ttl = 60
 	records = [ "\"PC-Intel-2.4ghz\" \"Linux\"" ]
@@ -318,8 +318,8 @@ resource "powerdns_record" "test-hinfo" {
 
 const testPDNSRecordConfigLOC = `
 resource "powerdns_record" "test-loc" {
-  zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "LOC"
 	ttl = 60
 	records = [ "51 56 0.123 N 5 54 0.000 E 4.00m 1.00m 10000.00m 10.00m" ]
@@ -327,26 +327,26 @@ resource "powerdns_record" "test-loc" {
 
 const testPDNSRecordConfigMX = `
 resource "powerdns_record" "test-mx" {
-  zone = "sysa.xyz"
-	name = "sysa.xyz"
+	zone = "sysa.xyz."
+	name = "sysa.xyz."
 	type = "MX"
 	ttl = 60
-	records = [ "10 mail.example.com" ]
+	records = [ "10 mail.example.com." ]
 }`
 
 const testPDNSRecordConfigMXMulti = `
 resource "powerdns_record" "test-mx-multi" {
-  zone = "sysa.xyz"
-	name = "sysa.xyz"
+	zone = "sysa.xyz."
+	name = "sysa.xyz."
 	type = "MX"
 	ttl = 60
-	records = [ "10 mail1.example.com", "20 mail2.example.com" ]
+	records = [ "10 mail1.example.com.", "20 mail2.example.com." ]
 }`
 
 const testPDNSRecordConfigNAPTR = `
 resource "powerdns_record" "test-naptr" {
-  zone = "sysa.xyz"
-	name = "sysa.xyz"
+	zone = "sysa.xyz"
+	name = "sysa.xyz."
 	type = "NAPTR"
 	ttl = 60
 	records = [ "100 50 \"s\" \"z3950+I2L+I2C\" \"\" _z3950._tcp.gatech.edu'." ]
@@ -354,17 +354,17 @@ resource "powerdns_record" "test-naptr" {
 
 const testPDNSRecordConfigNS = `
 resource "powerdns_record" "test-ns" {
-  zone = "sysa.xyz"
-	name = "lab.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "lab.sysa.xyz."
 	type = "NS"
 	ttl = 60
-	records = [ "ns1.sysa.xyz", "ns2.sysa.xyz" ]
+	records = [ "ns1.sysa.xyz.", "ns2.sysa.xyz." ]
 }`
 
 const testPDNSRecordConfigSPF = `
 resource "powerdns_record" "test-spf" {
-  zone = "sysa.xyz"
-	name = "sysa.xyz"
+	zone = "sysa.xyz."
+	name = "sysa.xyz."
 	type = "SPF"
 	ttl = 60
 	records = [ "\"v=spf1 +all\"" ]
@@ -372,8 +372,8 @@ resource "powerdns_record" "test-spf" {
 
 const testPDNSRecordConfigSSHFP = `
 resource "powerdns_record" "test-sshfp" {
-  zone = "sysa.xyz"
-	name = "ssh.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "ssh.sysa.xyz."
 	type = "SSHFP"
 	ttl = 60
 	records = [ "1 1 123456789abcdef67890123456789abcdef67890" ]
@@ -381,17 +381,17 @@ resource "powerdns_record" "test-sshfp" {
 
 const testPDNSRecordConfigSRV = `
 resource "powerdns_record" "test-srv" {
-  zone = "sysa.xyz"
-	name = "_redis._tcp.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "_redis._tcp.sysa.xyz."
 	type = "SRV"
 	ttl = 60
-	records = [ "0 10 6379 redis1.sysa.xyz", "0 10 6379 redis2.sysa.xyz", "10 10 6379 redis-replica.sysa.xyz" ]
+	records = [ "0 10 6379 redis1.sysa.xyz.", "0 10 6379 redis2.sysa.xyz.", "10 10 6379 redis-replica.sysa.xyz." ]
 }`
 
 const testPDNSRecordConfigTXT = `
 resource "powerdns_record" "test-txt" {
-  zone = "sysa.xyz"
-	name = "text.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "text.sysa.xyz."
 	type = "TXT"
 	ttl = 60
 	records = [ "\"text record payload\"" ]

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -20,7 +20,7 @@ For the v1 API (PowerDNS version 4):
 # Add a record to the zone
 resource "powerdns_record" "foobar" {
   zone    = "example.com."
-  name    = "www.example.com"
+  name    = "www.example.com."
   type    = "A"
   ttl     = 300
   records = ["192.168.0.11"]
@@ -44,8 +44,8 @@ For the legacy API (PowerDNS version 3.4):
 ```hcl
 # Add a record to the zone
 resource "powerdns_record" "foobar" {
-  zone    = "example.com"
-  name    = "www.example.com"
+  zone    = "example.com."
+  name    = "www.example.com."
   type    = "A"
   ttl     = 300
   records = ["192.168.0.11"]
@@ -61,4 +61,3 @@ The following arguments are supported:
 * `type` - (Required) The record type.
 * `ttl` - (Required) The TTL of the record.
 * `records` - (Required) A string list of records.
-


### PR DESCRIPTION
So that contributors can run acceptance tests with a one-liner, without compiling and configuring pdns. If this makes sense, we should also be able to run acceptance tests on travis with it.

Based on #7.

cc @wjwoodson