### PR TITLE
Fix reverse DNS lookup functional test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
       curl -X POST http://pdns:8081/api/v1/servers/localhost/zones \
         -d '{"name": "sysa.xyz.", "kind": "Native", "nameservers": ["ns1.sysa.xyz."]}' \
         -H "X-API-Key: secret"
+      curl -s -X POST http://pdns:8081/api/v1/servers/localhost/zones \
+        -d '{"name": "in-addr.arpa.", "kind": "Native", "nameservers": ["ns1.sysa.xyz."]}' \
+        -H "X-API-Key: secret"
       make testacc
     environment:
       PDNS_SERVER_URL: http://pdns:8081

--- a/powerdns/resource_powerdns_record_test.go
+++ b/powerdns/resource_powerdns_record_test.go
@@ -297,8 +297,8 @@ resource "powerdns_record" "test-a" {
 
 const testPDNSRecordConfigAWithPtr = `
 resource "powerdns_record" "test-a-ptr" {
-	zone = "sysa.xyz"
-	name = "redis.sysa.xyz"
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
 	type = "A"
 	ttl = 60
 	set_ptr = true


### PR DESCRIPTION
- Uses canonical naming for created zone and name
- Adds an appropriate in-addr.arpa. zone for reverse lookup

Now `make testacc` and `docker-compose run --rm testacc` work :-)