### PR TITLE
docker-compose: Update so that tests can run outside

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,10 @@ In order to test the provider, you can simply run `make test`.
 $ make test
 ```
 
-In order to run the full suite of acceptance tests, run `make testacc`.
+You can use `docker-compose` to prepare test environment for acceptance tests:
 
 ```sh
-$ make testacc
-```
-
-You can also run acceptance tests using `docker-compose`:
-
-```sh
-docker-compose run --rm testacc
+docker-compose run --rm setup
+PDNS_SERVER_URL=http://localhost:8081 PDNS_API_KEY=secret make testacc
+docker-compose down
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,9 @@ services:
       MYSQL_PASS: secret
     depends_on:
     - mysql
-  testacc:
+    ports:
+    - "8081:8081"
+  setup:
     image: golang
     command:
     - sh
@@ -35,12 +37,5 @@ services:
       curl -s -X POST http://pdns:8081/api/v1/servers/localhost/zones \
         -d '{"name": "in-addr.arpa.", "kind": "Native", "nameservers": ["ns1.sysa.xyz."]}' \
         -H "X-API-Key: secret"
-      make testacc
-    environment:
-      PDNS_SERVER_URL: http://pdns:8081
-      PDNS_API_KEY: secret
-    volumes:
-    - .:/go/src/github.com/terraform-providers/terraform-provider-powerdns
-    working_dir: /go/src/github.com/terraform-providers/terraform-provider-powerdns
     depends_on:
     - pdns


### PR DESCRIPTION
This is necessary for test runners such as the one in TeamCity so that test output can be parsed correctly.

This might not be necessary in the future as CI adapts to standardised JSON output of Go test tooling, but it is today.