### PR TITLE
Add tests for SOA records

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         sleep 1
       done
       curl -X POST http://pdns:8081/api/v1/servers/localhost/zones \
-        -d '{"name": "sysa.xyz.", "kind": "Native", "nameservers": ["ns1.sysa.xyz."]}' \
+        -d '{"name": "sysa.xyz.", "kind": "Native", "soa_edit_api": "", "nameservers": ["ns1.sysa.xyz."]}' \
         -H "X-API-Key: secret"
       curl -s -X POST http://pdns:8081/api/v1/servers/localhost/zones \
         -d '{"name": "in-addr.arpa.", "kind": "Native", "nameservers": ["ns1.sysa.xyz."]}' \

--- a/powerdns/resource_powerdns_record_test.go
+++ b/powerdns/resource_powerdns_record_test.go
@@ -239,6 +239,22 @@ func TestAccPDNSRecord_TXT(t *testing.T) {
 	})
 }
 
+func TestAccPDNSRecord_SOA(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPDNSRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPDNSRecordConfigSOA,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPDNSRecordExists("powerdns_record.test-soa"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPDNSRecordDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "powerdns_record" {
@@ -421,4 +437,13 @@ resource "powerdns_record" "test-txt" {
 	type = "TXT"
 	ttl = 60
 	records = [ "\"text record payload\"" ]
+}`
+
+const testPDNSRecordConfigSOA = `
+resource "powerdns_record" "test-soa" {
+	zone = "sysa.xyz."
+	name = "sysa.xyz."
+	type = "SOA"
+	ttl = 3600
+	records = [ "something.something. hostmaster.sysa.xyz. 2019090301 10800 3600 604800 3600" ]
 }`


### PR DESCRIPTION
This PR only adds tests for SOA records. For that to work, the zone must have `soa_edit_api` set to `""`, otherwise the test will fail. 
For details on `soa_edit_api` refer to [PowerDNS documentation](https://doc.powerdns.com/authoritative/domainmetadata.html#soa-edit-api).