### PR TITLE
zone and record resources import

### DIFF
--- a/powerdns/resource_powerdns_record.go
+++ b/powerdns/resource_powerdns_record.go
@@ -194,6 +194,7 @@ func resourcePDNSRecordImport(d *schema.ResourceData, meta interface{}) ([]*sche
 	for _, r := range records {
 		recs = append(recs, r.Content)
 	}
+
 	d.Set("zone", zoneName)
 	d.Set("name", records[0].Name)
 	d.Set("ttl", records[0].TTL)

--- a/powerdns/resource_powerdns_record.go
+++ b/powerdns/resource_powerdns_record.go
@@ -2,7 +2,6 @@ package powerdns
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 
@@ -171,12 +170,12 @@ func resourcePDNSRecordImport(d *schema.ResourceData, meta interface{}) ([]*sche
 
 	zoneName, ok := data["zone"]
 	if !ok {
-		return nil, errors.New("missing zone name in input data")
+		return nil, fmt.Errorf("missing zone name in input data")
 	}
 
 	recordID, ok := data["id"]
 	if !ok {
-		return nil, errors.New("missing record id in input data")
+		return nil, fmt.Errorf("missing record id in input data")
 	}
 
 	log.Printf("[INFO] importing PowerDNS Record %s in Zone: %s", recordID, zoneName)
@@ -187,7 +186,7 @@ func resourcePDNSRecordImport(d *schema.ResourceData, meta interface{}) ([]*sche
 	}
 
 	if len(records) == 0 {
-		return nil, errors.New("rrset has no records to import")
+		return nil, fmt.Errorf("rrset has no records to import")
 	}
 
 	recs := make([]string, 0, len(records))

--- a/powerdns/resource_powerdns_record_test.go
+++ b/powerdns/resource_powerdns_record_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestAccPDNSRecord_A(t *testing.T) {
+	resourceName := "powerdns_record.test-a"
+	resourceID := `{"zone":"sysa.xyz.","id":"redis.sysa.xyz.:::A"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -17,14 +20,23 @@ func TestAccPDNSRecord_A(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigA,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-a"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_WithPtr(t *testing.T) {
+	resourceName := "powerdns_record.test-a-ptr"
+	resourceID := `{"zone":"sysa.xyz.","id":"redis.sysa.xyz.:::A"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -33,14 +45,24 @@ func TestAccPDNSRecord_WithPtr(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigAWithPtr,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-a-ptr"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateId:           resourceID,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"set_ptr"},
 			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_WithCount(t *testing.T) {
+	resourceID0 := `{"zone":"sysa.xyz.","id":"redis-0.sysa.xyz.:::A"}`
+	resourceID1 := `{"zone":"sysa.xyz.","id":"redis-1.sysa.xyz.:::A"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -53,11 +75,26 @@ func TestAccPDNSRecord_WithCount(t *testing.T) {
 					testAccCheckPDNSRecordExists("powerdns_record.test-counted.1"),
 				),
 			},
+			{
+				ResourceName:      "powerdns_record.test-counted[0]",
+				ImportStateId:     resourceID0,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "powerdns_record.test-counted[1]",
+				ImportStateId:     resourceID1,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_AAAA(t *testing.T) {
+	resourceName := "powerdns_record.test-aaaa"
+	resourceID := `{"zone":"sysa.xyz.","id":"redis.sysa.xyz.:::AAAA"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -66,14 +103,23 @@ func TestAccPDNSRecord_AAAA(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigAAAA,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-aaaa"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_CNAME(t *testing.T) {
+	resourceName := "powerdns_record.test-cname"
+	resourceID := `{"zone":"sysa.xyz.","id":"redis.sysa.xyz.:::CNAME"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -82,14 +128,23 @@ func TestAccPDNSRecord_CNAME(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigCNAME,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-cname"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_HINFO(t *testing.T) {
+	resourceName := "powerdns_record.test-hinfo"
+	resourceID := `{"zone":"sysa.xyz.","id":"redis.sysa.xyz.:::HINFO"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -98,14 +153,23 @@ func TestAccPDNSRecord_HINFO(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigHINFO,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-hinfo"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_LOC(t *testing.T) {
+	resourceName := "powerdns_record.test-loc"
+	resourceID := `{"zone":"sysa.xyz.","id":"redis.sysa.xyz.:::LOC"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -114,14 +178,24 @@ func TestAccPDNSRecord_LOC(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigLOC,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-loc"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_MX(t *testing.T) {
+	resourceName := "powerdns_record.test-mx"
+	resourceNameMulti := "powerdns_record.test-mx-multi"
+	resourceID := `{"zone":"sysa.xyz.","id":"sysa.xyz.:::MX"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -130,20 +204,35 @@ func TestAccPDNSRecord_MX(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigMX,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-mx"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testPDNSRecordConfigMXMulti,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-mx-multi"),
+					testAccCheckPDNSRecordExists(resourceNameMulti),
 				),
+			},
+			{
+				ResourceName:      resourceNameMulti,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_NAPTR(t *testing.T) {
+	resourceName := "powerdns_record.test-naptr"
+	resourceID := `{"zone":"sysa.xyz.","id":"sysa.xyz.:::NAPTR"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -152,14 +241,23 @@ func TestAccPDNSRecord_NAPTR(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigNAPTR,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-naptr"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_NS(t *testing.T) {
+	resourceName := "powerdns_record.test-ns"
+	resourceID := `{"zone":"sysa.xyz.","id":"lab.sysa.xyz.:::NS"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -168,14 +266,23 @@ func TestAccPDNSRecord_NS(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigNS,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-ns"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_SPF(t *testing.T) {
+	resourceName := "powerdns_record.test-spf"
+	resourceID := `{"zone":"sysa.xyz.","id":"sysa.xyz.:::SPF"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -184,14 +291,23 @@ func TestAccPDNSRecord_SPF(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigSPF,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-spf"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_SSHFP(t *testing.T) {
+	resourceName := "powerdns_record.test-sshfp"
+	resourceID := `{"zone":"sysa.xyz.","id":"ssh.sysa.xyz.:::SSHFP"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -200,14 +316,23 @@ func TestAccPDNSRecord_SSHFP(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigSSHFP,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-sshfp"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_SRV(t *testing.T) {
+	resourceName := "powerdns_record.test-srv"
+	resourceID := `{"zone":"sysa.xyz.","id":"_redis._tcp.sysa.xyz.:::SRV"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -216,14 +341,23 @@ func TestAccPDNSRecord_SRV(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigSRV,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-srv"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_TXT(t *testing.T) {
+	resourceName := "powerdns_record.test-txt"
+	resourceID := `{"zone":"sysa.xyz.","id":"text.sysa.xyz.:::TXT"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -232,14 +366,23 @@ func TestAccPDNSRecord_TXT(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigTXT,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-txt"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccPDNSRecord_SOA(t *testing.T) {
+	resourceName := "powerdns_record.test-soa"
+	resourceID := `{"zone":"sysa.xyz.","id":"sysa.xyz.:::SOA"}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -248,8 +391,14 @@ func TestAccPDNSRecord_SOA(t *testing.T) {
 			{
 				Config: testPDNSRecordConfigSOA,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSRecordExists("powerdns_record.test-soa"),
+					testAccCheckPDNSRecordExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     resourceID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -387,7 +536,7 @@ resource "powerdns_record" "test-mx-multi" {
 
 const testPDNSRecordConfigNAPTR = `
 resource "powerdns_record" "test-naptr" {
-	zone = "sysa.xyz"
+	zone = "sysa.xyz."
 	name = "sysa.xyz."
 	type = "NAPTR"
 	ttl = 60

--- a/powerdns/resource_powerdns_record_test.go
+++ b/powerdns/resource_powerdns_record_test.go
@@ -194,7 +194,7 @@ func TestAccPDNSRecord_LOC(t *testing.T) {
 func TestAccPDNSRecord_MX(t *testing.T) {
 	resourceName := "powerdns_record.test-mx"
 	resourceNameMulti := "powerdns_record.test-mx-multi"
-	resourceID := `{"zone":"sysa.xyz.","id":"sysa.xyz.:::MX"}`
+	resourceID := `{"zone":"sysa.xyz.","id":"multi.sysa.xyz.:::MX"}`
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/powerdns/resource_powerdns_record_test.go
+++ b/powerdns/resource_powerdns_record_test.go
@@ -194,7 +194,8 @@ func TestAccPDNSRecord_LOC(t *testing.T) {
 func TestAccPDNSRecord_MX(t *testing.T) {
 	resourceName := "powerdns_record.test-mx"
 	resourceNameMulti := "powerdns_record.test-mx-multi"
-	resourceID := `{"zone":"sysa.xyz.","id":"multi.sysa.xyz.:::MX"}`
+	resourceID := `{"zone":"sysa.xyz.","id":"sysa.xyz.:::MX"}`
+	resourceIDMulti := `{"zone":"sysa.xyz.","id":"multi.sysa.xyz.:::MX"}`
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -221,7 +222,7 @@ func TestAccPDNSRecord_MX(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceNameMulti,
-				ImportStateId:     resourceID,
+				ImportStateId:     resourceIDMulti,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/powerdns/resource_powerdns_zone.go
+++ b/powerdns/resource_powerdns_zone.go
@@ -73,20 +73,20 @@ func resourcePDNSZoneRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Couldn't fetch PowerDNS Zone: %s", err)
 	}
 
-	nameservers, err := client.ListRecordsInRRSet(zoneInfo.Name, zoneInfo.Name, "NS")
-	if err != nil {
-		return fmt.Errorf("couldn't fetch zone %s nameservers from PowerDNS: %v", zoneInfo.Name, err)
-	}
-
-	var zoneNameservers []string
-	for _, nameserver := range nameservers {
-		zoneNameservers = append(zoneNameservers, nameserver.Content)
-	}
-
 	d.Set("name", zoneInfo.Name)
 	d.Set("kind", zoneInfo.Kind)
 
 	if zoneInfo.Kind != "Slave" {
+		nameservers, err := client.ListRecordsInRRSet(zoneInfo.Name, zoneInfo.Name, "NS")
+		if err != nil {
+			return fmt.Errorf("couldn't fetch zone %s nameservers from PowerDNS: %v", zoneInfo.Name, err)
+		}
+
+		var zoneNameservers []string
+		for _, nameserver := range nameservers {
+			zoneNameservers = append(zoneNameservers, nameserver.Content)
+		}
+
 		d.Set("nameservers", zoneNameservers)
 	}
 

--- a/powerdns/resource_powerdns_zone.go
+++ b/powerdns/resource_powerdns_zone.go
@@ -1,8 +1,6 @@
 package powerdns
 
 import (
-	//"encoding/json"
-	//"errors"
 	"fmt"
 	"log"
 

--- a/powerdns/resource_powerdns_zone.go
+++ b/powerdns/resource_powerdns_zone.go
@@ -85,7 +85,10 @@ func resourcePDNSZoneRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", zoneInfo.Name)
 	d.Set("kind", zoneInfo.Kind)
-	d.Set("nameservers", zoneNameservers)
+
+	if zoneInfo.Kind != "Slave" {
+		d.Set("nameservers", zoneNameservers)
+	}
 
 	return nil
 }

--- a/powerdns/resource_powerdns_zone_test.go
+++ b/powerdns/resource_powerdns_zone_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccPDNSZone(t *testing.T) {
+	resourceName := "powerdns_zone.test"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -17,10 +19,15 @@ func TestAccPDNSZone(t *testing.T) {
 			{
 				Config: testPDNSZoneConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPDNSZoneExists("powerdns_zone.test"),
+					testAccCheckPDNSZoneExists(resourceName),
 					resource.TestCheckResourceAttr("powerdns_zone.test", "name", "sysa.abc."),
 					resource.TestCheckResourceAttr("powerdns_zone.test", "kind", "Native"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/powerdns/resource_powerdns_zone_test.go
+++ b/powerdns/resource_powerdns_zone_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccPDNSZone(t *testing.T) {
-	resourceName := "powerdns_zone.test"
+func TestAccPDNSZoneNative(t *testing.T) {
+	resourceName := "powerdns_zone.test-native"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,11 +17,11 @@ func TestAccPDNSZone(t *testing.T) {
 		CheckDestroy: testAccCheckPDNSZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testPDNSZoneConfig,
+				Config: testPDNSZoneConfigNative,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPDNSZoneExists(resourceName),
-					resource.TestCheckResourceAttr("powerdns_zone.test", "name", "sysa.abc."),
-					resource.TestCheckResourceAttr("powerdns_zone.test", "kind", "Native"),
+					resource.TestCheckResourceAttr(resourceName, "name", "sysa.abc."),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Native"),
 				),
 			},
 			{
@@ -33,6 +33,55 @@ func TestAccPDNSZone(t *testing.T) {
 	})
 }
 
+func TestAccPDNSZoneMaster(t *testing.T) {
+	resourceName := "powerdns_zone.test-master"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPDNSZoneConfigMaster,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPDNSZoneExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "sysa.abc."),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Master"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPDNSZoneSlave(t *testing.T) {
+	resourceName := "powerdns_zone.test-slave"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPDNSZoneConfigSlave,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPDNSZoneExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "sysa.abc."),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Slave"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
 func testAccCheckPDNSZoneDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "powerdns_zone" {
@@ -71,9 +120,23 @@ func testAccCheckPDNSZoneExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testPDNSZoneConfig = `
-resource "powerdns_zone" "test" {
+const testPDNSZoneConfigNative = `
+resource "powerdns_zone" "test-native" {
 	name = "sysa.abc."
 	kind = "Native"
 	nameservers = ["ns1.sysa.abc.", "ns2.sysa.abc."]
+}`
+
+const testPDNSZoneConfigMaster = `
+resource "powerdns_zone" "test-master" {
+	name = "sysa.abc."
+	kind = "Master"
+	nameservers = ["ns1.sysa.abc.", "ns2.sysa.abc."]
+}`
+
+const testPDNSZoneConfigSlave = `
+resource "powerdns_zone" "test-slave" {
+	name = "sysa.abc."
+	kind = "Slave"
+	nameservers = []
 }`

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -78,3 +78,19 @@ The following arguments are supported:
 * `type` - (Required) The record type.
 * `ttl` - (Required) The TTL of the record.
 * `records` - (Required) A string list of records.
+
+### Attribute Reference
+
+The id of the resource is a composite of the record name and record type, joined by a separator - `:::`.
+
+For example, record `foo.test.com.` of type `A` will be represented with the following `id`: `foo.test.com.:::A`
+
+### Importing
+
+An existing record can be imported into this resource by supplying both the record id and zone name it belongs to.
+If the record or zone is not found, or if the record is of a different type or in a different zone, an error will be returned.
+
+For example:
+```sh
+$ terraform import powerdns_record.test-a `'{"zone": "test.com.", "id": "foo.test.com.:::A"}'`
+```

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -94,3 +94,6 @@ For example:
 ```sh
 $ terraform import powerdns_record.test-a `'{"zone": "test.com.", "id": "foo.test.com.:::A"}'`
 ```
+
+For more information on how to use terraform's `import` command, please refer to terraform's [core documentation](https://www.terraform.io/docs/import/index.html#currently-state-only).
+

--- a/website/docs/r/zone.html.markdown
+++ b/website/docs/r/zone.html.markdown
@@ -30,3 +30,12 @@ The following arguments are supported:
 * `name` - (Required) The name of zone.
 * `kind` - (Required) The kind of the zone.
 * `nameservers` - (Required) The zone nameservers.
+
+## Importing
+
+An existing zone can be imported into this resource by supplying the zone name. If the zone is not found, an error will be returned. 
+
+For example, to import zone `test.com.`:
+```sh
+$ terraform import powerdns_zone.test test.com.
+```

--- a/website/docs/r/zone.html.markdown
+++ b/website/docs/r/zone.html.markdown
@@ -39,3 +39,5 @@ For example, to import zone `test.com.`:
 ```sh
 $ terraform import powerdns_zone.test test.com.
 ```
+
+For more information on how to use terraform's `import` command, please refer to terraform's [core documentation](https://www.terraform.io/docs/import/index.html#currently-state-only).


### PR DESCRIPTION
fixes #31 

Importing zones requires the zone name to be passed as resource id.
```
$ terraform import powerdns_zone.test test.com.
```

Importing records requires the following input data:
```
$ terraform import powerdns_record.test-a `'{"zone": "<zone name>.", "id": "<record id>"}'`
```

To Do:
- [x] Tests
- [x] Documentation