### PR TITLE
validate value of records

### DIFF
--- a/powerdns/resource_powerdns_record.go
+++ b/powerdns/resource_powerdns_record.go
@@ -38,7 +38,6 @@ func resourcePDNSRecord() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-
 			"records": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -70,15 +69,32 @@ func resourcePDNSRecordCreate(d *schema.ResourceData, meta interface{}) error {
 	ttl := d.Get("ttl").(int)
 	recs := d.Get("records").(*schema.Set).List()
 	setPtr := false
+
 	if v, ok := d.GetOk("set_ptr"); ok {
 		setPtr = v.(bool)
 	}
 
+	// begin: ValidateFunc
+	// https://www.terraform.io/docs/extend/schemas/schema-behaviors.html
+	// "ValidateFunc is not yet supported on lists or sets"
+	// when terraform will support ValidateFunc for non-primitives
+	// we can move this block there
+	if !(len(recs) > 0) {
+		return fmt.Errorf("'records' must not be empty")
+	}
+	// end: ValidateFunc
+
 	if len(recs) > 0 {
 		records := make([]Record, 0, len(recs))
 		for _, recContent := range recs {
-			records = append(records, Record{Name: rrSet.Name, Type: rrSet.Type, TTL: ttl, Content: recContent.(string), SetPtr: setPtr})
+			records = append(records,
+				Record{Name: rrSet.Name,
+					Type:    rrSet.Type,
+					TTL:     ttl,
+					Content: recContent.(string),
+					SetPtr:  setPtr})
 		}
+
 		rrSet.Records = records
 
 		log.Printf("[DEBUG] Creating PowerDNS Record: %#v", rrSet)
@@ -91,14 +107,6 @@ func resourcePDNSRecordCreate(d *schema.ResourceData, meta interface{}) error {
 		d.SetId(recID)
 		log.Printf("[INFO] Created PowerDNS Record with ID: %s", d.Id())
 
-	} else {
-		log.Printf("[DEBUG] Deleting empty PowerDNS Record: %#v", rrSet)
-		err := client.DeleteRecordSet(zone, rrSet.Name, rrSet.Type)
-		if err != nil {
-			return fmt.Errorf("Failed to delete PowerDNS Record: %s", err)
-		}
-
-		d.SetId(rrSet.ID())
 	}
 
 	return resourcePDNSRecordRead(d, meta)

--- a/powerdns/resource_powerdns_record.go
+++ b/powerdns/resource_powerdns_record.go
@@ -3,6 +3,7 @@ package powerdns
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -79,6 +80,11 @@ func resourcePDNSRecordCreate(d *schema.ResourceData, meta interface{}) error {
 	// "ValidateFunc is not yet supported on lists or sets"
 	// when terraform will support ValidateFunc for non-primitives
 	// we can move this block there
+	for _, recs := range recs {
+		if len(strings.Trim(recs.(string), " ")) == 0 {
+			log.Printf("[WARN] One or more values in 'records' contain empty '' value(s)")
+		}
+	}
 	if !(len(recs) > 0) {
 		return fmt.Errorf("'records' must not be empty")
 	}

--- a/powerdns/resource_powerdns_record_test.go
+++ b/powerdns/resource_powerdns_record_test.go
@@ -2,11 +2,25 @@ package powerdns
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func TestAccPDNSRecord_Empty(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testPDNSRecordConfigRecordEmpty,
+				ExpectError: regexp.MustCompile("'records' must not be empty"),
+			},
+		},
+	})
+}
 
 func TestAccPDNSRecord_A(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -301,6 +315,15 @@ func testAccCheckPDNSRecordExists(n string) resource.TestCheckFunc {
 		return fmt.Errorf("Record does not exist: %#v", rs.Primary.ID)
 	}
 }
+
+const testPDNSRecordConfigRecordEmpty = `
+resource "powerdns_record" "test-a" {
+	zone = "sysa.xyz."
+	name = "redis.sysa.xyz."
+	type = "A"
+	ttl = 60
+	records = [ ]
+}`
 
 const testPDNSRecordConfigA = `
 resource "powerdns_record" "test-a" {


### PR DESCRIPTION
Closes #33 

The apply looks like this:

```
$ cat test.tf
resource "powerdns_record" "foobar" {
  zone    = "sysa.xyz."
  name    = "something.sysa.xyz."
  type    = "A"
  ttl     = 300
  records = ["127.0.0.1"]
}

resource "powerdns_record" "foobar1" {
  zone    = "sysa.xyz."
  name    = "something1.sysa.xyz."
  type    = "A"
  ttl     = 300
  records = []
}

resource "powerdns_record" "foobar2" {
  zone    = "sysa.xyz."
  name    = "something2.sysa.xyz."
  type    = "A"
  ttl     = 300
  records = [""]
}

resource "powerdns_record" "foobar3" {
  zone    = "sysa.xyz."
  name    = "something3.sysa.xyz."
  type    = "A"
  ttl     = 300
  records = ["", "127.0.0.2"]
}

$ terraform init > /dev/null 2>&1
$ make build && \
cp $GOPATH/bin/terraform-provider-powerdns .terraform/plugins/darwin_amd64/terraform-provider-powerdns_v1.1.0_x4 && \
terraform init && \
terraform apply -auto-approve

==> Checking that code complies with gofmt requirements...
go install

Initializing the backend...

Initializing provider plugins...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.powerdns: version = "~> 1.1"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
powerdns_record.foobar: Refreshing state... [id=something.sysa.xyz.:::A]
powerdns_record.foobar2: Creating...
powerdns_record.foobar3: Creating...
powerdns_record.foobar1: Creating...

Error: 'records' must not be empty

  on test.tf line 9, in resource "powerdns_record" "foobar1":
   9: resource "powerdns_record" "foobar1" {



Error: all values in 'records' must contain non-empty strings

  on test.tf line 17, in resource "powerdns_record" "foobar2":
  17: resource "powerdns_record" "foobar2" {



Error: all values in 'records' must contain non-empty strings

  on test.tf line 25, in resource "powerdns_record" "foobar3":
  25: resource "powerdns_record" "foobar3" {
```