### PR TITLE
[docs] minor cosmetic fixes for import docs

### DIFF
--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -91,8 +91,9 @@ An existing record can be imported into this resource by supplying both the reco
 If the record or zone is not found, or if the record is of a different type or in a different zone, an error will be returned.
 
 For example:
-```sh
-$ terraform import powerdns_record.test-a `'{"zone": "test.com.", "id": "foo.test.com.:::A"}'`
+
+```
+$ terraform import powerdns_record.test-a '{"zone": "test.com.", "id": "foo.test.com.:::A"}'
 ```
 
 For more information on how to use terraform's `import` command, please refer to terraform's [core documentation](https://www.terraform.io/docs/import/index.html#currently-state-only).

--- a/website/docs/r/zone.html.markdown
+++ b/website/docs/r/zone.html.markdown
@@ -36,7 +36,8 @@ The following arguments are supported:
 An existing zone can be imported into this resource by supplying the zone name. If the zone is not found, an error will be returned. 
 
 For example, to import zone `test.com.`:
-```sh
+
+```
 $ terraform import powerdns_zone.test test.com.
 ```
 


### PR DESCRIPTION
I noticed that the import command examples are being rendered strangely with the GH markdown styles I used, so I cleaned that up to make it look better aligned.