### PR TITLE
add option soa_edit_api

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,10 +14,10 @@ build: fmtcheck
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=20
+		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=5
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v -parallel 20 $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test $(TEST) -v -parallel 5 $(TESTARGS) -timeout 120m
 
 vet:
 	@echo "go vet ."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,13 @@ services:
         fi
         sleep 1
       done
+      # this is used for records acc testing except SOA
       curl -X POST http://pdns:8081/api/v1/servers/localhost/zones \
-        -d '{"name": "sysa.xyz.", "kind": "Native", "soa_edit_api": "", "nameservers": ["ns1.sysa.xyz."]}' \
+        -d '{"name": "sysa.xyz.", "kind": "Native", "nameservers": ["ns1.sysa.xyz."]}' \
+        -H "X-API-Key: secret"
+      # this is used for SOA record testing
+      curl -X POST http://pdns:8081/api/v1/servers/localhost/zones \
+        -d '{"name": "test-soa-sysa.xyz.", "kind": "Native", "soa_edit_api": "", "nameservers": ["ns1.sysa.xyz."]}' \
         -H "X-API-Key: secret"
       curl -s -X POST http://pdns:8081/api/v1/servers/localhost/zones \
         -d '{"name": "in-addr.arpa.", "kind": "Native", "nameservers": ["ns1.sysa.xyz."]}' \

--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -156,6 +156,7 @@ type ZoneInfo struct {
 	Records            []Record            `json:"records,omitempty"`
 	ResourceRecordSets []ResourceRecordSet `json:"rrsets,omitempty"`
 	Nameservers        []string            `json:"nameservers,omitempty"`
+	SoaEditAPI         string              `json:"soa_edit_api,"`
 }
 
 // Record represents a PowerDNS record object

--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -156,7 +156,7 @@ type ZoneInfo struct {
 	Records            []Record            `json:"records,omitempty"`
 	ResourceRecordSets []ResourceRecordSet `json:"rrsets,omitempty"`
 	Nameservers        []string            `json:"nameservers,omitempty"`
-	SoaEditAPI         string              `json:"soa_edit_api,"`
+	SoaEditAPI         string              `json:"soa_edit_api"`
 }
 
 // Record represents a PowerDNS record object

--- a/powerdns/resource_powerdns_record_test.go
+++ b/powerdns/resource_powerdns_record_test.go
@@ -396,7 +396,7 @@ func TestAccPDNSRecord_TXT(t *testing.T) {
 
 func TestAccPDNSRecord_SOA(t *testing.T) {
 	resourceName := "powerdns_record.test-soa"
-	resourceID := `{"zone":"sysa.xyz.","id":"sysa.xyz.:::SOA"}`
+	resourceID := `{"zone":"test-soa-sysa.xyz.","id":"test-soa-sysa.xyz.:::SOA"}`
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -614,8 +614,8 @@ resource "powerdns_record" "test-txt" {
 
 const testPDNSRecordConfigSOA = `
 resource "powerdns_record" "test-soa" {
-	zone = "sysa.xyz."
-	name = "sysa.xyz."
+	zone = "test-soa-sysa.xyz."
+	name = "test-soa-sysa.xyz."
 	type = "SOA"
 	ttl = 3600
 	records = [ "something.something. hostmaster.sysa.xyz. 2019090301 10800 3600 604800 3600" ]

--- a/powerdns/resource_powerdns_zone.go
+++ b/powerdns/resource_powerdns_zone.go
@@ -36,6 +36,11 @@ func resourcePDNSZone() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"soa_edit_api": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
 		},
 	}
 }
@@ -52,6 +57,7 @@ func resourcePDNSZoneCreate(d *schema.ResourceData, meta interface{}) error {
 		Name:        d.Get("name").(string),
 		Kind:        d.Get("kind").(string),
 		Nameservers: nameservers,
+		SoaEditAPI:  d.Get("soa_edit_api").(string),
 	}
 
 	createdZoneInfo, err := client.CreateZone(zoneInfo)
@@ -75,6 +81,7 @@ func resourcePDNSZoneRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", zoneInfo.Name)
 	d.Set("kind", zoneInfo.Kind)
+	d.Set("soa_edit_api", zoneInfo.SoaEditAPI)
 
 	if zoneInfo.Kind != "Slave" {
 		nameservers, err := client.ListRecordsInRRSet(zoneInfo.Name, zoneInfo.Name, "NS")

--- a/powerdns/resource_powerdns_zone_test.go
+++ b/powerdns/resource_powerdns_zone_test.go
@@ -58,6 +58,85 @@ func TestAccPDNSZoneMaster(t *testing.T) {
 	})
 }
 
+func TestAccPDNSZoneMasterSOAAPIEDIT(t *testing.T) {
+	resourceName := "powerdns_zone.test-master-soa-edit-api"
+	resourceSOAEDITAPI := `DEFAULT`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPDNSZoneConfigMasterSOAEDITAPI,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPDNSZoneExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "master-soa-edit-api.sysa.abc."),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Master"),
+					resource.TestCheckResourceAttr(resourceName, "soa_edit_api", resourceSOAEDITAPI),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPDNSZoneMasterSOAAPIEDITEmpty(t *testing.T) {
+	resourceName := "powerdns_zone.test-master-soa-edit-api-empty"
+	resourceSOAEDITAPI := `""`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPDNSZoneConfigMasterSOAEDITAPIEmpty,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPDNSZoneExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "master-soa-edit-api-empty.sysa.abc."),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Master"),
+					resource.TestCheckResourceAttr(resourceName, "soa_edit_api", resourceSOAEDITAPI),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPDNSZoneMasterSOAAPIEDITUndefined(t *testing.T) {
+	resourceName := "powerdns_zone.test-master-soa-edit-api-undefined"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPDNSZoneConfigMasterSOAEDITAPIUndefined,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPDNSZoneExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "master-soa-edit-api-undefined.sysa.abc."),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Master"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccPDNSZoneSlave(t *testing.T) {
 	resourceName := "powerdns_zone.test-slave"
 
@@ -130,6 +209,29 @@ resource "powerdns_zone" "test-native" {
 const testPDNSZoneConfigMaster = `
 resource "powerdns_zone" "test-master" {
 	name = "master.sysa.abc."
+	kind = "Master"
+	nameservers = ["ns1.sysa.abc.", "ns2.sysa.abc."]
+}`
+
+const testPDNSZoneConfigMasterSOAEDITAPI = `
+resource "powerdns_zone" "test-master-soa-edit-api" {
+	name = "master-soa-edit-api.sysa.abc."
+	kind = "Master"
+	nameservers = ["ns1.sysa.abc.", "ns2.sysa.abc."]
+	soa_edit_api = "DEFAULT"
+}`
+
+const testPDNSZoneConfigMasterSOAEDITAPIEmpty = `
+resource "powerdns_zone" "test-master-soa-edit-api-empty" {
+	name = "master-soa-edit-api-empty.sysa.abc."
+	kind = "Master"
+	nameservers = ["ns1.sysa.abc.", "ns2.sysa.abc."]
+	soa_edit_api = "\"\""
+}`
+
+const testPDNSZoneConfigMasterSOAEDITAPIUndefined = `
+resource "powerdns_zone" "test-master-soa-edit-api-undefined" {
+	name = "master-soa-edit-api-undefined.sysa.abc."
 	kind = "Master"
 	nameservers = ["ns1.sysa.abc.", "ns2.sysa.abc."]
 }`

--- a/website/docs/r/zone.html.markdown
+++ b/website/docs/r/zone.html.markdown
@@ -30,10 +30,11 @@ The following arguments are supported:
 * `name` - (Required) The name of zone.
 * `kind` - (Required) The kind of the zone.
 * `nameservers` - (Required) The zone nameservers.
+* `soa_edit_api` - (Optional) This should map to one of the [supported API values](https://doc.powerdns.com/authoritative/dnsupdate.html#soa-edit-dnsupdate-settings) *or* in [case you wish to remove the setting](https://doc.powerdns.com/authoritative/domainmetadata.html#soa-edit-api), set this argument as `\"\"` (that will translate to the API value `""`).
 
 ## Importing
 
-An existing zone can be imported into this resource by supplying the zone name. If the zone is not found, an error will be returned. 
+An existing zone can be imported into this resource by supplying the zone name. If the zone is not found, an error will be returned.
 
 For example, to import zone `test.com.`:
 


### PR DESCRIPTION
Feature: 

- Add support for `soa_edit_api` argument in the `zone` resource. The argument is optional and doesn't introduce breaking change. Closes #40 

Minor:

- Tests: Adds a new zone for SOA Record testing. With introduction of parallel tests, deleting the SOA record (during SOA Record test) will make the other record tests to fail.