### PR TITLE
Update client tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ script:
 - make website-test
 - docker-compose run --rm setup
 # run test using custom root CA
-- PDNS_SERVER_URL=localhost:4443 PDNS_API_KEY=secret PDNS_CACERT="$PWD/tests/files/ssl/rootCA/rootCA.crt" make testacc
+- TESTARGS="-run ^TestAcc" PDNS_SERVER_URL=localhost:4443 PDNS_API_KEY=secret PDNS_CACERT="$PWD/tests/files/ssl/rootCA/rootCA.crt" make testacc
 # run test skipping TLS verification (Insecure HTTPS)
-- PDNS_SERVER_URL=localhost:4443 PDNS_API_KEY=secret PDNS_INSECURE_HTTPS=true make testacc
+- TESTARGS="-run ^TestAcc" PDNS_SERVER_URL=localhost:4443 PDNS_API_KEY=secret PDNS_INSECURE_HTTPS=true make testacc
 - docker-compose down
 
 branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.3.1 (Unreleased)
+
+FIXES:
+  * **Updated client tests to test sanitizeURL directly** [GH-51]
+
 ## 1.3.0 (December 20, 2019)
 
 FEATURES:
@@ -23,7 +27,7 @@ FIXES:
 
 ## 1.1.0 (August 13, 2019)
 
-FEATURES: 
+FEATURES:
   * **HTTPS Custom CA**: added option for custom Root CA for HTTPS Certificate validation (option `ca_certificate`) ([#22](https://github.com/terraform-providers/terraform-provider-powerdns/issues/22))
   * **HTTPS**: added option to skip HTTPS certificate validation - insecure HTTPS (option `insecure_https`) ([#22](https://github.com/terraform-providers/terraform-provider-powerdns/issues/22))
 
@@ -37,8 +41,8 @@ NOTES:
  * provider: This release includes only a Terraform SDK upgrade with compatibility for Terraform v0.12. The provider remains backwards compatible with Terraform v0.11 and this update should have no significant changes in behavior for the provider. Please report any unexpected behavior in new GitHub issues (Terraform core: https://github.com/hashicorp/terraform/issues or Terraform PowerDNS Provider: https://github.com/terraform-providers/terraform-provider-powerdns/issues) ([#16](https://github.com/terraform-providers/terraform-provider-powerdns/issues/16))
 
 ENHANCEMENTS:
-  * Switch to go modules and Terraform v0.12 SDK [[#16](https://github.com/terraform-providers/terraform-provider-powerdns/issues/16)] 
-  
+  * Switch to go modules and Terraform v0.12 SDK [[#16](https://github.com/terraform-providers/terraform-provider-powerdns/issues/16)]
+
 ## 0.2.0 (July 31, 2019)
 
 FEATURES:

--- a/powerdns/client_test.go
+++ b/powerdns/client_test.go
@@ -1,7 +1,6 @@
 package powerdns
 
 import (
-	"crypto/tls"
 	"strings"
 	"testing"
 
@@ -9,7 +8,6 @@ import (
 )
 
 var (
-	tlsConfig                               = &tls.Config{}
 	URLMissingSchemaAndNotEndingWithSlash   = "powerdnsapi.com"
 	URLMissingSchemaAndEndingWithSlash      = "powerdnsapi.com/"
 	URLWithSchemaAndEndingWithSlash         = "http://powerdnsapi.com/"
@@ -22,90 +20,82 @@ var (
 )
 
 func TestURLMissingSchema(t *testing.T) {
-	client, err := NewClient(URLMissingSchemaAndNotEndingWithSlash,
-		"secretapikey", tlsConfig)
+	url, err := sanitizeURL(URLMissingSchemaAndNotEndingWithSlash)
 	assert.NoError(t, err)
 
 	expectedURL := DefaultSchema + "://" + URLMissingSchemaAndNotEndingWithSlash
-
-	assert.Equal(t, client.ServerURL, expectedURL,
-		"Expected '"+expectedURL+"' but got '"+client.ServerURL+"'")
+	assert.Equal(t, url, expectedURL,
+		"Expected '"+expectedURL+"' but got '"+url+"'")
 }
 
 func TestURLMissingSchemaAndEndingWithSlash(t *testing.T) {
-	client, err := NewClient(URLMissingSchemaAndEndingWithSlash,
-		"secretapikey", tlsConfig)
+	url, err := sanitizeURL(URLMissingSchemaAndEndingWithSlash)
 	assert.NoError(t, err)
 
 	expectedURL := DefaultSchema + "://" +
 		strings.TrimSuffix(URLMissingSchemaAndEndingWithSlash, "/")
 
-	assert.Equal(t, client.ServerURL, expectedURL,
-		"Expected '"+expectedURL+"' but got '"+client.ServerURL+"'")
+	assert.Equal(t, url, expectedURL,
+		"Expected '"+expectedURL+"' but got '"+url+"'")
 }
 
 func TestURLWithSchemaAndEndingWithSlash(t *testing.T) {
-	client, err := NewClient(URLWithSchemaAndEndingWithSlash,
-		"secretapikey", tlsConfig)
+	url, err := sanitizeURL(URLWithSchemaAndEndingWithSlash)
 	assert.NoError(t, err)
 
 	expectedURL := strings.TrimSuffix(URLWithSchemaAndEndingWithSlash, "/")
 
-	assert.Equal(t, client.ServerURL, expectedURL,
-		"Expected '"+expectedURL+"' but got '"+client.ServerURL+"'")
+	assert.Equal(t, url, expectedURL,
+		"Expected '"+expectedURL+"' but got '"+url+"'")
 }
 
 func TestURLWithSchemaAndNotEndingWithSlash(t *testing.T) {
-	client, err := NewClient(URLWithSchemaAndNotEndingWithSlash,
-		"secretapikey", tlsConfig)
+	url, err := sanitizeURL(URLWithSchemaAndNotEndingWithSlash)
 	assert.NoError(t, err)
 
 	expectedURL := URLWithSchemaAndNotEndingWithSlash
 
-	assert.Equal(t, client.ServerURL, expectedURL,
-		"Expected '"+expectedURL+"' but got '"+client.ServerURL+"'")
+	assert.Equal(t, url, expectedURL,
+		"Expected '"+expectedURL+"' but got '"+url+"'")
 }
 
 func TestURLMissingSchemaHasPort(t *testing.T) {
-	client, err := NewClient(URLMissingSchemaHasPort, "secretapikey", tlsConfig)
+	url, err := sanitizeURL(URLMissingSchemaHasPort)
 	assert.NoError(t, err)
 
 	expectedURL := DefaultSchema + "://" + URLMissingSchemaHasPort
 
-	assert.Equal(t, client.ServerURL, expectedURL,
-		"Expected '"+expectedURL+"' but got '"+client.ServerURL+"'")
+	assert.Equal(t, url, expectedURL,
+		"Expected '"+expectedURL+"' but got '"+url+"'")
 }
 
 func TestURLMissingSchemaHasPortAndEndsWithSlash(t *testing.T) {
-	client, err := NewClient(URLMissingSchemaHasPortAndEndsWithSlash,
-		"secretapikey", tlsConfig)
+	url, err := sanitizeURL(URLMissingSchemaHasPortAndEndsWithSlash)
 	assert.NoError(t, err)
 
 	expectedURL := DefaultSchema + "://" +
 		strings.TrimSuffix(URLMissingSchemaHasPortAndEndsWithSlash, "/")
 
-	assert.Equal(t, client.ServerURL, expectedURL,
-		"Expected '"+expectedURL+"' but got '"+client.ServerURL+"'")
+	assert.Equal(t, url, expectedURL,
+		"Expected '"+expectedURL+"' but got '"+url+"'")
 }
 
 func TestURLWithSchemaHasPort(t *testing.T) {
-	client, err := NewClient(URLWithSchemaHasPort,
-		"secretapikey", tlsConfig)
+	url, err := sanitizeURL(URLWithSchemaHasPort)
 	assert.NoError(t, err)
 
 	expectedURL := URLWithSchemaHasPort
 
-	assert.Equal(t, client.ServerURL, expectedURL,
-		"Expected '"+expectedURL+"' but got '"+client.ServerURL+"'")
+	assert.Equal(t, url, expectedURL,
+		"Expected '"+expectedURL+"' but got '"+url+"'")
 }
 
 func TestURLWithSchemaHasPortAndEndsWithSlash(t *testing.T) {
-	client, err := NewClient(URLWithSchemaHasPortAndEndsWithSlash,
-		"secretapikey", tlsConfig)
+	url, err := sanitizeURL(URLWithSchemaHasPortAndEndsWithSlash)
 	assert.NoError(t, err)
 
 	expectedURL := strings.TrimSuffix(URLWithSchemaHasPortAndEndsWithSlash, "/")
 
-	assert.Equal(t, client.ServerURL, expectedURL,
-		"Expected '"+expectedURL+"' but got '"+client.ServerURL+"'")
+	assert.Equal(t, url, expectedURL,
+		"Expected '"+expectedURL+"' but got '"+url+"'")
 }


### PR DESCRIPTION
Client tests were testing `sanitizeURL` by creating a new client. I changed it to test `sanitizeURL` directly. I also set a `TESTARGS` to run only tests starting with `TestAcc` during acceptance testing.