### PR TITLE
Add ServerVersion attribute to client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.3.1 (Unreleased)
 
+FEATURES:
+  * **Added ServerVersion attribute to client** [GH-52]
+
 FIXES:
   * **Updated client tests to test sanitizeURL directly** [GH-51]
 

--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -592,10 +592,16 @@ func (client *Client) setServerVersion() error {
 
 	serverInfo := new(serverInfo)
 	err = json.NewDecoder(resp.Body).Decode(serverInfo)
-	if err != nil {
-		return err
+	if err == nil {
+		client.ServerVersion = serverInfo.Version
+		return nil
 	}
 
-	client.ServerVersion = serverInfo.Version
-	return nil
+	headerServerInfo := strings.SplitN(resp.Header.Get("Server"), "/", 2)
+	if len(headerServerInfo) == 2 && strings.EqualFold(headerServerInfo[0], "PowerDNS") {
+		client.ServerVersion = headerServerInfo[1]
+		return nil
+	}
+
+	return fmt.Errorf("Unable to get server version")
 }


### PR DESCRIPTION
I've added a `ServerVersion` attribute to client. It might be useful for dealing with features that will be deprecated in future API versions. (e.g. `set-ptr`)

BTW, it should not be a breaking change since all powerdns versions support the called api ([4.1 & 4.2](https://doc.powerdns.com/authoritative/http-api/server.html), [4.0.x](https://doc.powerdns.com/md/httpapi/api_spec/#servers), [3.x](https://doc.powerdns.com/3/httpapi/api_spec/#servers)).