### PR TITLE
Fix kind case sensitive

### DIFF
--- a/powerdns/resource_powerdns_zone.go
+++ b/powerdns/resource_powerdns_zone.go
@@ -30,10 +30,7 @@ func resourcePDNSZone() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if strings.ToLower(old) == strings.ToLower(new) {
-						return true
-					}
-					return false
+					return strings.EqualFold(old, new)
 				},
 			},
 

--- a/powerdns/resource_powerdns_zone.go
+++ b/powerdns/resource_powerdns_zone.go
@@ -3,6 +3,7 @@ package powerdns
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -28,6 +29,12 @@ func resourcePDNSZone() *schema.Resource {
 			"kind": {
 				Type:     schema.TypeString,
 				Required: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if strings.ToLower(old) == strings.ToLower(new) {
+						return true
+					}
+					return false
+				},
 			},
 
 			"nameservers": {

--- a/powerdns/resource_powerdns_zone_test.go
+++ b/powerdns/resource_powerdns_zone_test.go
@@ -33,6 +33,52 @@ func TestAccPDNSZoneNative(t *testing.T) {
 	})
 }
 
+func TestAccPDNSZoneNativeMixedCaps(t *testing.T) {
+	resourceName := "powerdns_zone.test-native"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				// using mixed caps config to create resource with test-native name
+				Config: testPDNSZoneConfigNativeMixedCaps,
+			},
+			{
+				// using test-native config with Native to confirm plan doesn't generate diff
+				ResourceName:       resourceName,
+				Config:             testPDNSZoneConfigNative,
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+			},
+		},
+	})
+}
+
+func TestAccPDNSZoneNativeSmallCaps(t *testing.T) {
+	resourceName := "powerdns_zone.test-native"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				// using small caps config to create resource with test-native name
+				Config: testPDNSZoneConfigNativeSmallCaps,
+			},
+			{
+				// using test-native config with Native to confirm plan doesn't generate diff
+				ResourceName:       resourceName,
+				Config:             testPDNSZoneConfigNative,
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+			},
+		},
+	})
+}
+
 func TestAccPDNSZoneMaster(t *testing.T) {
 	resourceName := "powerdns_zone.test-master"
 
@@ -203,6 +249,20 @@ const testPDNSZoneConfigNative = `
 resource "powerdns_zone" "test-native" {
 	name = "sysa.abc."
 	kind = "Native"
+	nameservers = ["ns1.sysa.abc.", "ns2.sysa.abc."]
+}`
+
+const testPDNSZoneConfigNativeMixedCaps = `
+resource "powerdns_zone" "test-native" {
+	name = "sysa.abc."
+	kind = "NaTIve"
+	nameservers = ["ns1.sysa.abc.", "ns2.sysa.abc."]
+}`
+
+const testPDNSZoneConfigNativeSmallCaps = `
+resource "powerdns_zone" "test-native" {
+	name = "sysa.abc."
+	kind = "native"
 	nameservers = ["ns1.sysa.abc.", "ns2.sysa.abc."]
 }`
 


### PR DESCRIPTION
This patch will suppress terraform performing apply on zone resource, when values in kind attribute have different case.

Closes #46 