### PR TITLE
Added masters attribute to zone

### DIFF
--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -161,6 +161,7 @@ type ZoneInfo struct {
 	Records            []Record            `json:"records,omitempty"`
 	ResourceRecordSets []ResourceRecordSet `json:"rrsets,omitempty"`
 	Nameservers        []string            `json:"nameservers,omitempty"`
+	Masters            []string            `json:"masters,omitempty"`
 	SoaEditAPI         string              `json:"soa_edit_api"`
 }
 

--- a/powerdns/resource_powerdns_zone.go
+++ b/powerdns/resource_powerdns_zone.go
@@ -67,11 +67,11 @@ func resourcePDNSZoneCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	var masters []string
-	for _, master_ip := range d.Get("masters").(*schema.Set).List() {
-		if net.ParseIP(master_ip.(string)) == nil {
-			return fmt.Errorf("Values in masters list attribute must be valid IPs.")
+	for _, masterIP := range d.Get("masters").(*schema.Set).List() {
+		if net.ParseIP(masterIP.(string)) == nil {
+			return fmt.Errorf("values in masters list attribute must be valid IPs")
 		}
-		masters = append(masters, master_ip.(string))
+		masters = append(masters, masterIP.(string))
 	}
 
 	zoneInfo := ZoneInfo{

--- a/powerdns/resource_powerdns_zone_test.go
+++ b/powerdns/resource_powerdns_zone_test.go
@@ -244,7 +244,7 @@ func TestAccPDNSZoneSlaveWithInvalidMasters(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testPDNSZoneConfigSlaveWithInvalidMasters,
-				ExpectError: regexp.MustCompile("Values in masters list attribute must be valid IPs."),
+				ExpectError: regexp.MustCompile("values in masters list attribute must be valid IPs"),
 			},
 		},
 	})

--- a/website/docs/r/zone.html.markdown
+++ b/website/docs/r/zone.html.markdown
@@ -17,9 +17,18 @@ For the v1 API (PowerDNS version 4):
 ```hcl
 # Add a zone
 resource "powerdns_zone" "foobar" {
-  name    = "example.com."
-  kind    = "Native"
+  name        = "example.com."
+  kind        = "Native"
   nameservers = ["ns1.example.com.", "ns2.example.com."]
+}
+```
+
+```hcl
+# Add a Slave zone with list of IPs configured as a master for this zone
+resource "powerdns_zone" "fubar" {
+  name     = "slave.example.com."
+  kind     = "Slave"
+  masters  = ["10.10.10.10", "20.20.20.21"]
 }
 ```
 
@@ -29,7 +38,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of zone.
 * `kind` - (Required) The kind of the zone.
-* `nameservers` - (Required) The zone nameservers.
+* `nameservers` - (Optional) The zone nameservers.
+* `masters` - (Optional) List of IP addresses configured as a master for this zone (“Slave” kind zones only)
 * `soa_edit_api` - (Optional) This should map to one of the [supported API values](https://doc.powerdns.com/authoritative/dnsupdate.html#soa-edit-dnsupdate-settings) *or* in [case you wish to remove the setting](https://doc.powerdns.com/authoritative/domainmetadata.html#soa-edit-api), set this argument as `\"\"` (that will translate to the API value `""`).
 
 ## Importing


### PR DESCRIPTION
When setting up Slave zone, masters attribute can be used to set IPs configured to be masters of the slave zone.

Closes #53 